### PR TITLE
bugfix: Fix permission problems when running packages from unprivileged user account

### DIFF
--- a/datascience/Dockerfile
+++ b/datascience/Dockerfile
@@ -244,4 +244,8 @@ RUN set -xe && \
 RUN apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
+# Fix Permissions for directories like .local and .mix
+USER root
+RUN chown -R $NB_USER:users /home/$NB_USER
+
 USER $NB_UID


### PR DESCRIPTION
For example, executing `jupyter notebook --ip 0.0.0.0 --port 8888 results in an error writing cookie_secret to .local/share/jupyter/runtime/notebook_cookie_secret

This fix assigns all files in the home directory to user '$NB_USER' and group 'users'.