### PR TITLE
bugfix: Outdated dependency for IR kernel libicu, installed .58

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,74 @@ Quickstart:
 make
 make start
 ```
+
+### Description 
+A Jupyter Lab based container for data science projects.
+
+### Usage
+`docker run --rm -it -p 8888:8888 nicbet/jupyter-datascience` starts the jupyter lab server on port 8888. Then connect to http://localhost:8888 with the token printed to the console.
+
+### Included Packages:
+- python>=3.6.6
+- rpy2>=2.9.4
+- r-base=3.4.1
+- r-irkernel>=0.8.12
+- r-plyr>=1.8.4
+- r-devtools>=1.13.6
+- r-tidyverse>=1.1.1
+- r-irkernel>=0.8.12
+- r-plyr>=1.8.4
+- r-devtools>=1.13.6
+- r-shiny>=1.0.5
+- r-rmarkdown>=1.9
+- r-forecast>=8.2
+- r-rsqlite>=2.0
+- r-reshape2>=1.4.3
+- r-nycflights13>=1.0.0
+- r-caret>=6.0_80
+- r-rcurl>=1.95_4.11
+- r-crayon>=1.3.4
+- r-randomforest>=4.6_12
+- r-htmltools>=0.3.6
+- r-sparklyr>=0.8.3
+- r-htmlwidgets>=1.0
+- r-hexbin>=1.27.2
+- tensorflow>=1.9.0
+- keras>=2.2.2
+- pytorch=0.4.*
+- chainer=4.3.*
+- theano=1.*.*
+- opencv
+- caffe
+- jupyterthemes>=0.19.6
+- plotly>=3.1.1
+- imbalanced-learn>=0.3.3
+- psycopg2>=2.7.5
+- tabulate>=0.8.2
+- ipywidgets>=7.4.0
+- pandas=0.23*
+- numexpr=2.6*
+- matplotlib=2.2*
+- scipy=1.1*
+- seaborn=0.9*
+- scikit-learn=0.19*
+- scikit-image=0.14*
+- sympy=1.1*
+- cython=0.28*
+- patsy=0.5*
+- statsmodels=0.9*
+- cloudpickle=0.5*
+- dill=0.2*
+- numba=0.38*
+- bokeh=0.12*
+- sqlalchemy=1.2*
+- hdf5=1.10*
+- h5py=2.7*
+- vincent=0.4.*
+- beautifulsoup4=4.6.*
+- protobuf=3.*
+- xlrd
+- jupyter_nbextensions_configurator=0.4*
+- jupyter_contrib_nbextensions=0.5*
+- Elixir 1.7
+- Julia 1.0

--- a/datascience/Dockerfile
+++ b/datascience/Dockerfile
@@ -30,12 +30,14 @@ RUN ln -fs /opt/julia-*/bin/julia /usr/local/bin/julia
 RUN mkdir /etc/julia && \
     echo "push!(Libdl.DL_LOAD_PATH, \"$CONDA_DIR/lib\")" >> /etc/julia/juliarc.jl && \
     # Create JULIA_PKGDIR \
-    mkdir $JULIA_PKGDIR && \
-    chown $NB_USER $JULIA_PKGDIR
+    mkdir $JULIA_PKGDIR  
 
 USER $NB_UID
 
-RUN conda config --add channels r
+# https://github.com/jupyter/docker-stacks/pull/499
+# https://github.com/jupyter/docker-stacks/issues/497
+RUN conda config --append channels r
+RUN conda config --prepend channels conda-forge
 
 RUN conda install --quiet --yes \
     'python>=3.6.6' \
@@ -238,14 +240,10 @@ RUN set -xe && \
     mix deps.get && \
     mix local.rebar --forcea && \
     mix deps.compile && \
-    ./install_script.sh \
-    chown $NB_USER /opt/ielixir-${IELIXIR_VERSION}
+    ./install_script.sh 
 
 RUN apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
-# Fix Permissions for directories like .local and .mix
-USER root
-RUN chown -R $NB_USER:users /home/$NB_USER
-
+RUN chown -R $NB_USER:users /home/$NB_USER /opt/ielixir-*
 USER $NB_UID

--- a/datascience/Makefile
+++ b/datascience/Makefile
@@ -10,7 +10,7 @@ all: $(tag)
 # Build the docker image
 $(tag): Dockerfile check-env
 	$(info Building image with tag $(tag))
-	@docker build -t $(tag) .
+	@docker build -t $(tag) --squash .
 
 # Deploy the image to docker.io
 push: $(tag)


### PR DESCRIPTION
When starting R kernel, kernel keep dying with

```
Error: package or namespace load failed for 'stringi' in dyn.load(file, DLLpath = DLLpath, ...):
 unable to load shared object '/data/kensche/work/share/miniconda3/envs/test/lib/R/library/stringi/libs/stringi.so':
  libicui18n.so.54: cannot open shared object file: No such file or directory
```

`conda list` shows icu installed at .58

Resolution is to prepend conda-forge channel.

Resolves:
#3

See also:
https://conda-forge.org/docs/conda-forge_gotchas.html
https://github.com/jupyter/docker-stacks/pull/499
https://github.com/jupyter/docker-stacks/issues/497